### PR TITLE
Add Stream Deck API for external control

### DIFF
--- a/docs/help/streamdeck-api.md
+++ b/docs/help/streamdeck-api.md
@@ -1,0 +1,1065 @@
+# Stream Deck API Documentation
+
+## Overview
+
+The Stream Deck API is a REST API designed specifically for Stream Deck integration, enabling seamless control of your streaming workflow from physical Stream Deck buttons. This API provides endpoints for managing streaming status, restream control, teleprompter navigation, overlays, questions, chat, and operator modes.
+
+All endpoints are optimized for Stream Deck compatibility and accept empty bodies for POST requests when no parameters are required.
+
+## Base URL
+
+```
+/api/streamdeck
+```
+
+**Full URL Format:**
+```
+http://[your-server]:[port]/api/streamdeck
+```
+
+Replace `[your-server]` with your server's hostname or IP address, and `[port]` with your API port (typically 5000 for HTTP or 5001 for HTTPS).
+
+## Response Format
+
+All Stream Deck API endpoints return a standardized JSON envelope with the following structure:
+
+```json
+{
+  "success": true|false,
+  "message": "Human-readable message",
+  "data": {},
+  "error": null|"Error details if applicable"
+}
+```
+
+### Response Envelope Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | boolean | Indicates whether the request was successful |
+| `message` | string | Human-readable status message |
+| `data` | object | Response payload (structure varies by endpoint) |
+| `error` | string \| null | Error details if the request failed |
+
+### Success Response Example
+
+```json
+{
+  "success": true,
+  "message": "Go-live workflow executed",
+  "data": null,
+  "error": null
+}
+```
+
+### Error Response Example
+
+```json
+{
+  "success": false,
+  "message": "Streaming failed",
+  "data": null,
+  "error": "Connection timeout"
+}
+```
+
+---
+
+## Endpoint Groups
+
+### Streaming Control
+
+Manage your main streaming status and control go-live and stop workflows.
+
+#### Get Streaming Status
+
+Retrieve the current streaming status and state.
+
+**Endpoint:** `GET /api/streamdeck/streaming/status`
+
+**Method:** GET  
+**Authentication:** Not required  
+**Query Parameters:** None
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "isRunning": true,
+    "state": "Started"
+  },
+  "error": null
+}
+```
+
+**Response Fields (data):**
+| Field | Type | Description |
+|-------|------|-------------|
+| `isRunning` | boolean | Whether streaming is currently active |
+| `state` | string | Current streaming state (e.g., "Started", "Stopped") |
+
+**Example curl:**
+```bash
+curl -X GET "http://localhost:5000/api/streamdeck/streaming/status"
+```
+
+---
+
+#### Go Live
+
+Execute the complete go-live workflow, preparing all systems for streaming.
+
+**Endpoint:** `POST /api/streamdeck/streaming/go-live`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Go-live workflow executed",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/streaming/go-live"
+```
+
+**Common Use Case:** Press a Stream Deck button to start your complete streaming workflow in one action.
+
+---
+
+#### Stop Streaming
+
+Stop the active stream.
+
+**Endpoint:** `POST /api/streamdeck/streaming/stop`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Streaming stopped",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/streaming/stop"
+```
+
+---
+
+### Restream Control
+
+Manage your restream status and control which platforms are currently active.
+
+#### Get Restream Status
+
+Retrieve the current restream status and enabled platforms.
+
+**Endpoint:** `GET /api/streamdeck/restream/status`
+
+**Method:** GET  
+**Authentication:** Not required  
+**Query Parameters:** None
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "isRunning": true,
+    "destinations": [
+      {
+        "platformName": "Twitch",
+        "isEnabled": true
+      },
+      {
+        "platformName": "YouTube",
+        "isEnabled": false
+      }
+    ]
+  },
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X GET "http://localhost:5000/api/streamdeck/restream/status"
+```
+
+---
+
+#### Start Restream
+
+Start restreaming to all enabled destinations.
+
+**Endpoint:** `POST /api/streamdeck/restream/start`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Restream started",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/restream/start"
+```
+
+---
+
+#### Stop Restream
+
+Stop restreaming to all destinations.
+
+**Endpoint:** `POST /api/streamdeck/restream/stop`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Restream stopped",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/restream/stop"
+```
+
+---
+
+#### Enable Platform
+
+Enable restreaming to a specific platform.
+
+**Endpoint:** `POST /api/streamdeck/restream/destinations/{platform}/enable`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `platform` | string | Platform name (e.g., "Twitch", "YouTube", "Facebook") |
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Twitch enabled",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/restream/destinations/Twitch/enable"
+```
+
+---
+
+#### Disable Platform
+
+Disable restreaming to a specific platform.
+
+**Endpoint:** `POST /api/streamdeck/restream/destinations/{platform}/disable`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `platform` | string | Platform name (e.g., "Twitch", "YouTube", "Facebook") |
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "YouTube disabled",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/restream/destinations/YouTube/disable"
+```
+
+---
+
+#### Toggle Platform
+
+Toggle the restream status for a specific platform (enable if disabled, disable if enabled).
+
+**Endpoint:** `POST /api/streamdeck/restream/destinations/{platform}/toggle`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `platform` | string | Platform name (e.g., "Twitch", "YouTube", "Facebook") |
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Twitch disabled",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/restream/destinations/Twitch/toggle"
+```
+
+**Common Use Case:** Create a single Stream Deck button that toggles a platform on or off without needing to know the current state.
+
+---
+
+### Teleprompter Control
+
+Navigate teleprompter content with simple scroll commands.
+
+#### Scroll Up
+
+Scroll the teleprompter content upward.
+
+**Endpoint:** `POST /api/streamdeck/teleprompter/scroll/up`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Scrolled up",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/teleprompter/scroll/up"
+```
+
+**Common Use Case:** Create Stream Deck buttons for hands-free teleprompter control while streaming.
+
+---
+
+#### Scroll Down
+
+Scroll the teleprompter content downward.
+
+**Endpoint:** `POST /api/streamdeck/teleprompter/scroll/down`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Scrolled down",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/teleprompter/scroll/down"
+```
+
+---
+
+### Overlay Control
+
+Manage and test overlay components.
+
+#### Get Overlay Components
+
+Retrieve a list of available overlay components.
+
+**Endpoint:** `GET /api/streamdeck/overlay/components`
+
+**Method:** GET  
+**Authentication:** Not required  
+**Query Parameters:** None
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": [
+    "Timer",
+    "SceneIndicator",
+    "ChatFeed",
+    "DonationCounter"
+  ],
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X GET "http://localhost:5000/api/streamdeck/overlay/components"
+```
+
+---
+
+#### Test Overlay Component
+
+Trigger a test display of a specific overlay component.
+
+**Endpoint:** `POST /api/streamdeck/overlay/{componentName}/test`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Path Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `componentName` | string | Name of the overlay component to test |
+
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Triggered test for Timer",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/overlay/Timer/test"
+```
+
+**Common Use Case:** Quickly verify overlays are working correctly before or during a stream.
+
+---
+
+### Questions Control
+
+Manage viewer questions and auto-detection settings.
+
+#### Get Questions
+
+Retrieve the current question dashboard state.
+
+**Endpoint:** `GET /api/streamdeck/questions`
+
+**Method:** GET  
+**Authentication:** Not required  
+**Query Parameters:** None
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "totalQuestions": 15,
+    "waitingQuestions": 12,
+    "selectedQuestion": {
+      "id": "q123",
+      "text": "What's your streaming setup?",
+      "author": "viewer123"
+    },
+    "liveQuestion": null,
+    "autoDetectEnabled": true
+  },
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X GET "http://localhost:5000/api/streamdeck/questions"
+```
+
+---
+
+#### Promote Next Question
+
+Promote the currently selected question to display as the live question.
+
+**Endpoint:** `POST /api/streamdeck/questions/next`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Next question promoted",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/questions/next"
+```
+
+**Common Use Case:** Press a Stream Deck button to quickly promote the next question in your queue.
+
+---
+
+#### Dismiss Live Question
+
+Dismiss the currently displayed live question.
+
+**Endpoint:** `POST /api/streamdeck/questions/dismiss`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Live question dismissed",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/questions/dismiss"
+```
+
+---
+
+#### Clear Waiting Questions
+
+Clear all questions currently waiting in the queue.
+
+**Endpoint:** `POST /api/streamdeck/questions/clear`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Waiting questions cleared",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/questions/clear"
+```
+
+---
+
+#### Enable Auto-Detect
+
+Enable automatic question detection.
+
+**Endpoint:** `POST /api/streamdeck/questions/autodetect/enable`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Auto-detect enabled",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/questions/autodetect/enable"
+```
+
+---
+
+#### Disable Auto-Detect
+
+Disable automatic question detection.
+
+**Endpoint:** `POST /api/streamdeck/questions/autodetect/disable`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Auto-detect disabled",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/questions/autodetect/disable"
+```
+
+---
+
+#### Toggle Auto-Detect
+
+Toggle automatic question detection (enable if disabled, disable if enabled).
+
+**Endpoint:** `POST /api/streamdeck/questions/autodetect/toggle`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Auto-detect enabled",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/questions/autodetect/toggle"
+```
+
+---
+
+### Chat Control
+
+Send messages to chat.
+
+#### Send Chat Message
+
+Send a message to the chat.
+
+**Endpoint:** `POST /api/streamdeck/chat/send`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `message` | string | Yes | The message text to send |
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Message sent",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/chat/send?message=Hello%20chat!"
+```
+
+**Example curl (with special characters):**
+```bash
+curl -X POST 'http://localhost:5000/api/streamdeck/chat/send?message=Thanks%20for%20watching%20%3A%29'
+```
+
+**Common Use Case:** Send quick responses or announcements with a Stream Deck button (use URL encoding for special characters).
+
+---
+
+### Operator Mode Control
+
+Check and set the current operator mode.
+
+#### Get Operator Mode
+
+Retrieve the current operator mode.
+
+**Endpoint:** `GET /api/streamdeck/operator/mode`
+
+**Method:** GET  
+**Authentication:** Not required  
+**Query Parameters:** None
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "mode": "Live"
+  },
+  "error": null
+}
+```
+
+**Response Fields (data):**
+| Field | Type | Description |
+|-------|------|-------------|
+| `mode` | string | Current mode ("PreLive" or "Live") |
+
+**Example curl:**
+```bash
+curl -X GET "http://localhost:5000/api/streamdeck/operator/mode"
+```
+
+---
+
+#### Set PreLive Mode
+
+Switch to PreLive mode for pre-stream preparation.
+
+**Endpoint:** `POST /api/streamdeck/operator/mode/prelive`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Mode set to PreLive",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/operator/mode/prelive"
+```
+
+---
+
+#### Set Live Mode
+
+Switch to Live mode for active streaming.
+
+**Endpoint:** `POST /api/streamdeck/operator/mode/live`
+
+**Method:** POST  
+**Authentication:** Not required  
+**Body:** Empty (or can omit body entirely)
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Mode set to Live",
+  "data": null,
+  "error": null
+}
+```
+
+**Example curl:**
+```bash
+curl -X POST "http://localhost:5000/api/streamdeck/operator/mode/live"
+```
+
+---
+
+## Stream Deck Setup Instructions
+
+### Prerequisites
+
+- Stream Deck device (any model with HTTP request support)
+- Stream Deck software installed on your computer
+- Network connectivity between your Stream Deck and the API server
+- API server running and accessible on your network
+
+### Step-by-Step Setup
+
+#### 1. Open Stream Deck Software
+
+Launch the Stream Deck application on your computer.
+
+#### 2. Add HTTP Request Action
+
+1. Create a new profile or edit an existing one
+2. Find the "System" category in the actions library
+3. Drag the **"HTTP Request"** action onto a button
+4. Release to create the action
+
+#### 3. Configure the HTTP Request
+
+Click on the HTTP Request button to open the settings panel:
+
+**Basic Configuration:**
+- **Request URL:** Enter your API endpoint (e.g., `http://localhost:5000/api/streamdeck/streaming/go-live`)
+- **Request Method:** Select GET or POST based on the endpoint
+- **On Successful Request:** Choose "No Action" or "Show OK" notification
+- **On Failed Request:** Choose "Show Error" notification
+
+**Example Configurations:**
+
+**Button 1 - Go Live:**
+```
+URL: http://your-server:5000/api/streamdeck/streaming/go-live
+Method: POST
+```
+
+**Button 2 - Stop Streaming:**
+```
+URL: http://your-server:5000/api/streamdeck/streaming/stop
+Method: POST
+```
+
+**Button 3 - Check Streaming Status:**
+```
+URL: http://your-server:5000/api/streamdeck/streaming/status
+Method: GET
+```
+
+**Button 4 - Next Question:**
+```
+URL: http://your-server:5000/api/streamdeck/questions/next
+Method: POST
+```
+
+**Button 5 - Toggle Twitch:**
+```
+URL: http://your-server:5000/api/streamdeck/restream/destinations/Twitch/toggle
+Method: POST
+```
+
+#### 4. Test Your Configuration
+
+1. Click the button on your Stream Deck device
+2. Verify the action executes (check server logs if available)
+3. Look for success/error notifications from Stream Deck
+
+#### 5. Customize Button Appearance
+
+You can customize button appearance in Stream Deck:
+- Add custom icon or image
+- Set a title (e.g., "Go Live", "Stop", "Next Question")
+- Configure long-press behavior for additional actions
+- Set up multi-action sequences
+
+### Network Configuration Tips
+
+**Local Network:**
+If your API is on the same local network:
+```
+http://[local-ip]:5000/api/streamdeck/endpoint
+```
+
+**Remote Access:**
+If you need remote access, set up a reverse proxy or use a domain name with appropriate security:
+```
+https://[your-domain]/api/streamdeck/endpoint
+```
+
+### Troubleshooting
+
+**"Connection Failed" Error:**
+- Verify the API server is running
+- Check the URL is correct (no typos)
+- Ensure firewall allows connections to your API port
+- Test with `curl` command to verify endpoint works
+
+**No Response from API:**
+- Check server logs for errors
+- Verify API port is accessible from your Stream Deck device
+- Test network connectivity: `ping [server-ip]`
+
+**Button Press Not Triggering Action:**
+- Verify HTTP Request action is properly configured
+- Check URL format and method (GET vs POST)
+- Test in Stream Deck settings before deploying to device
+
+---
+
+## Integration Examples
+
+### Example Workflow: Complete Stream Startup
+
+Create a multi-action sequence to go live with multiple platforms:
+
+1. **Button 1 (Single Press):** Execute go-live workflow
+   ```
+   POST /api/streamdeck/streaming/go-live
+   ```
+
+2. **Button 2 (Long Press):** Start restreaming
+   ```
+   POST /api/streamdeck/restream/start
+   ```
+
+### Example Workflow: Question Management
+
+Create a series of buttons for managing viewer questions:
+
+- **Button A:** Get Questions (GET)
+- **Button B:** Promote Next Question (POST)
+- **Button C:** Dismiss Question (POST)
+- **Button D:** Clear All Questions (POST)
+
+### Example Workflow: Platform Toggle
+
+Create individual buttons to manage which platforms are active:
+
+- **Button 1:** Toggle Twitch
+  ```
+  POST /api/streamdeck/restream/destinations/Twitch/toggle
+  ```
+
+- **Button 2:** Toggle YouTube
+  ```
+  POST /api/streamdeck/restream/destinations/YouTube/toggle
+  ```
+
+- **Button 3:** Toggle Facebook
+  ```
+  POST /api/streamdeck/restream/destinations/Facebook/toggle
+  ```
+
+---
+
+## Rate Limiting & Best Practices
+
+### Rate Limiting
+
+While there are no explicit rate limits on these endpoints, avoid excessive polling:
+
+- **Status checks:** Every 5-10 seconds maximum
+- **Actions:** Triggered by user interaction (no automated loops)
+- **Chat messages:** Reasonable delays between messages
+
+### Best Practices
+
+1. **Use POST for actions** that change state (starting/stopping, enabling/disabling)
+2. **Use GET for queries** that retrieve information
+3. **Minimize polling** of status endpoints - only check when needed
+4. **Include error handling** in Stream Deck configurations
+5. **Test URLs locally** before configuring Stream Deck
+6. **Document your button layout** for future reference
+
+---
+
+## Error Handling
+
+### Common Error Scenarios
+
+**Empty Message (Chat Endpoint):**
+```json
+{
+  "success": false,
+  "message": "Message cannot be empty",
+  "data": null,
+  "error": "Message cannot be empty"
+}
+```
+
+**Platform Not Found (Restream):**
+```json
+{
+  "success": false,
+  "message": "Platform not found",
+  "data": null,
+  "error": "Platform 'InvalidPlatform' not found"
+}
+```
+
+**Service Unavailable:**
+```json
+{
+  "success": false,
+  "message": "Service unavailable",
+  "data": null,
+  "error": "Connection failed"
+}
+```
+
+### Handling Errors in Stream Deck
+
+Stream Deck can be configured to:
+1. Show error notifications when requests fail
+2. Trigger alternative actions on failure
+3. Log errors for debugging
+
+---
+
+## Support & Troubleshooting
+
+For issues or questions:
+
+1. Check the endpoint URL format
+2. Verify the API server is running
+3. Test with curl commands
+4. Check network connectivity
+5. Review API server logs
+6. Verify your Stream Deck device is updated
+7. Test in Stream Deck settings panel
+
+---
+
+## Changelog
+
+**Version 1.0**
+- Initial API documentation
+- All core endpoints documented
+- Stream Deck setup instructions included
+- Example configurations provided

--- a/src/Thiccdal.API/StreamDeck/StreamDeckApiExtensions.cs
+++ b/src/Thiccdal.API/StreamDeck/StreamDeckApiExtensions.cs
@@ -1,0 +1,441 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Thiccdal.Infrastructure.Bot;
+using Thiccdal.Infrastructure.Operators;
+using Thiccdal.Infrastructure.Overlay;
+using Thiccdal.Infrastructure.Questions;
+using Thiccdal.Infrastructure.Streaming;
+using Thiccdal.Infrastructure.Teleprompter;
+
+#pragma warning disable CA1724 // Type names should not match namespaces
+
+namespace Thiccdal.API.StreamDeck;
+
+/// <summary>
+/// Registers the Stream Deck API endpoints optimized for Stream Deck integration.
+/// All POST endpoints accept empty bodies for Stream Deck compatibility.
+/// </summary>
+public static class StreamDeckApiExtensions
+{
+    /// <summary>
+    /// Maps all Stream Deck API endpoints.
+    /// </summary>
+    /// <param name="endpoints">The endpoint route builder.</param>
+    /// <returns>The updated endpoint route builder.</returns>
+    public static IEndpointRouteBuilder MapStreamDeckEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        ArgumentNullException.ThrowIfNull(endpoints);
+
+        RouteGroupBuilder group = endpoints.MapGroup("/api/streamdeck")
+            .WithTags("StreamDeck");
+
+        MapStreamingEndpoints(group);
+        MapRestreamEndpoints(group);
+        MapTeleprompterEndpoints(group);
+        MapOverlayEndpoints(group);
+        MapQuestionsEndpoints(group);
+        MapChatEndpoints(group);
+        MapOperatorEndpoints(group);
+
+        return endpoints;
+    }
+
+    private static void MapStreamingEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/streaming");
+
+        group.MapGet(
+                "/status",
+                static (IStreamingService streamingService) =>
+                {
+                    StreamingStatusData data = new StreamingStatusData(
+                        streamingService.IsRunning,
+                        streamingService.State.ToString());
+                    return Results.Ok(StreamDeckResponse<StreamingStatusData>.Ok(data));
+                })
+            .WithName("StreamDeck_GetStreamingStatus")
+            .Produces<StreamDeckResponse<StreamingStatusData>>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/go-live",
+                static async (IGoLiveActionService goLiveService, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        await goLiveService.Execute(cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok("Go-live workflow executed"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_GoLive")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/stop",
+                static async (IStreamingService streamingService, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        await streamingService.Stop(cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok("Streaming stopped"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_StopStreaming")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+
+    private static void MapRestreamEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/restream");
+
+        group.MapGet(
+                "/status",
+                static async (IRestreamRuntimeService restreamService, CancellationToken cancellationToken) =>
+                {
+                    RestreamControlState state = await restreamService.GetState(cancellationToken);
+                    return Results.Ok(StreamDeckResponse<RestreamControlState>.Ok(state));
+                })
+            .WithName("StreamDeck_GetRestreamStatus")
+            .Produces<StreamDeckResponse<RestreamControlState>>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/start",
+                static async (IRestreamRuntimeService restreamService, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        await restreamService.Start(cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok("Restream started"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_StartRestream")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/stop",
+                static async (IRestreamRuntimeService restreamService, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        await restreamService.Stop(cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok("Restream stopped"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_StopRestream")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/destinations/{platform}/enable",
+                static async (
+                    string platform,
+                    IRestreamRuntimeService restreamService,
+                    CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        RestreamDestinationUpdateRequest request = new RestreamDestinationUpdateRequest
+                        {
+                            PlatformName = platform,
+                            IsEnabled = true
+                        };
+                        await restreamService.UpdateDestination(request, cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok($"{platform} enabled"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_EnableDestination")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/destinations/{platform}/disable",
+                static async (
+                    string platform,
+                    IRestreamRuntimeService restreamService,
+                    CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        RestreamDestinationUpdateRequest request = new RestreamDestinationUpdateRequest
+                        {
+                            PlatformName = platform,
+                            IsEnabled = false
+                        };
+                        await restreamService.UpdateDestination(request, cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok($"{platform} disabled"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_DisableDestination")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/destinations/{platform}/toggle",
+                static async (
+                    string platform,
+                    IRestreamRuntimeService restreamService,
+                    CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        RestreamControlState state = await restreamService.GetState(cancellationToken);
+                        RestreamDestinationState? destination = state.Destinations
+                            .FirstOrDefault(d => string.Equals(d.PlatformName, platform, StringComparison.OrdinalIgnoreCase));
+
+                        if (destination is null)
+                        {
+                            return Results.Ok(StreamDeckResponse.Fail($"Platform '{platform}' not found"));
+                        }
+
+                        RestreamDestinationUpdateRequest request = new RestreamDestinationUpdateRequest
+                        {
+                            PlatformName = platform,
+                            IsEnabled = !destination.IsEnabled
+                        };
+                        await restreamService.UpdateDestination(request, cancellationToken);
+
+                        string newState = request.IsEnabled == true ? "enabled" : "disabled";
+                        return Results.Ok(StreamDeckResponse.Ok($"{platform} {newState}"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_ToggleDestination")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+
+    private static void MapTeleprompterEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/teleprompter");
+
+        group.MapPost(
+                "/scroll/up",
+                static (IOperatorStateService operatorState) =>
+                {
+                    operatorState.ScrollTeleprompter(ScrollDirection.Up);
+                    return Results.Ok(StreamDeckResponse.Ok("Scrolled up"));
+                })
+            .WithName("StreamDeck_TeleprompterScrollUp")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/scroll/down",
+                static (IOperatorStateService operatorState) =>
+                {
+                    operatorState.ScrollTeleprompter(ScrollDirection.Down);
+                    return Results.Ok(StreamDeckResponse.Ok("Scrolled down"));
+                })
+            .WithName("StreamDeck_TeleprompterScrollDown")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+
+    private static void MapOverlayEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/overlay");
+
+        group.MapGet(
+                "/components",
+                static (IOverlayService overlayService) =>
+                {
+                    IReadOnlyList<IOverlayComponent> components = overlayService.GetComponents();
+                    IReadOnlyList<string> names = components.Select(c => c.ComponentName).ToList();
+                    return Results.Ok(StreamDeckResponse<IReadOnlyList<string>>.Ok(names));
+                })
+            .WithName("StreamDeck_GetOverlayComponents")
+            .Produces<StreamDeckResponse<IReadOnlyList<string>>>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/{componentName}/test",
+                static (string componentName, IOperatorStateService operatorState) =>
+                {
+                    operatorState.TriggerOverlayTest(componentName);
+                    return Results.Ok(StreamDeckResponse.Ok($"Triggered test for {componentName}"));
+                })
+            .WithName("StreamDeck_TestOverlayComponent")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+
+    private static void MapQuestionsEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/questions");
+
+        group.MapGet(
+                string.Empty,
+                static (IQuestionOverlayService questionService) =>
+                {
+                    QuestionDashboardState state = questionService.GetState();
+                    return Results.Ok(StreamDeckResponse<QuestionDashboardState>.Ok(state));
+                })
+            .WithName("StreamDeck_GetQuestions")
+            .Produces<StreamDeckResponse<QuestionDashboardState>>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/next",
+                static (IQuestionOverlayService questionService) =>
+                {
+                    bool promoted = questionService.TryPromoteSelectedQuestion();
+                    if (promoted)
+                    {
+                        return Results.Ok(StreamDeckResponse.Ok("Next question promoted"));
+                    }
+                    return Results.Ok(StreamDeckResponse.Fail("No question to promote"));
+                })
+            .WithName("StreamDeck_NextQuestion")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/dismiss",
+                static (IQuestionOverlayService questionService) =>
+                {
+                    bool dismissed = questionService.TryDismissLiveQuestion();
+                    if (dismissed)
+                    {
+                        return Results.Ok(StreamDeckResponse.Ok("Live question dismissed"));
+                    }
+                    return Results.Ok(StreamDeckResponse.Fail("No live question to dismiss"));
+                })
+            .WithName("StreamDeck_DismissQuestion")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/clear",
+                static (IQuestionOverlayService questionService) =>
+                {
+                    questionService.ClearWaitingQuestions();
+                    return Results.Ok(StreamDeckResponse.Ok("Waiting questions cleared"));
+                })
+            .WithName("StreamDeck_ClearQuestions")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/autodetect/enable",
+                static (IQuestionOverlayService questionService) =>
+                {
+                    questionService.SetAutoDetect(true);
+                    return Results.Ok(StreamDeckResponse.Ok("Auto-detect enabled"));
+                })
+            .WithName("StreamDeck_EnableAutoDetect")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/autodetect/disable",
+                static (IQuestionOverlayService questionService) =>
+                {
+                    questionService.SetAutoDetect(false);
+                    return Results.Ok(StreamDeckResponse.Ok("Auto-detect disabled"));
+                })
+            .WithName("StreamDeck_DisableAutoDetect")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/autodetect/toggle",
+                static (IQuestionOverlayService questionService) =>
+                {
+                    QuestionDashboardState state = questionService.GetState();
+                    bool newState = !state.AutoDetectEnabled;
+                    questionService.SetAutoDetect(newState);
+                    string message = newState ? "Auto-detect enabled" : "Auto-detect disabled";
+                    return Results.Ok(StreamDeckResponse.Ok(message));
+                })
+            .WithName("StreamDeck_ToggleAutoDetect")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+
+    private static void MapChatEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/chat");
+
+        group.MapPost(
+                "/send",
+                static async (
+                    string message,
+                    IChatService chatService,
+                    CancellationToken cancellationToken) =>
+                {
+                    if (string.IsNullOrWhiteSpace(message))
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail("Message cannot be empty"));
+                    }
+
+                    try
+                    {
+                        await chatService.SendMessage(message, cancellationToken);
+                        return Results.Ok(StreamDeckResponse.Ok("Message sent"));
+                    }
+                    catch (Exception ex)
+                    {
+                        return Results.Ok(StreamDeckResponse.Fail(ex.Message));
+                    }
+                })
+            .WithName("StreamDeck_SendChat")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+
+    private static void MapOperatorEndpoints(RouteGroupBuilder parent)
+    {
+        RouteGroupBuilder group = parent.MapGroup("/operator");
+
+        group.MapGet(
+                "/mode",
+                static (IOperatorStateService operatorState) =>
+                {
+                    OperatorModeData data = new OperatorModeData(operatorState.Mode.ToString());
+                    return Results.Ok(StreamDeckResponse<OperatorModeData>.Ok(data));
+                })
+            .WithName("StreamDeck_GetOperatorMode")
+            .Produces<StreamDeckResponse<OperatorModeData>>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/mode/prelive",
+                static (IOperatorStateService operatorState) =>
+                {
+                    operatorState.SetMode(OperatorMode.PreLive);
+                    return Results.Ok(StreamDeckResponse.Ok("Mode set to PreLive"));
+                })
+            .WithName("StreamDeck_SetPreLiveMode")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+
+        group.MapPost(
+                "/mode/live",
+                static (IOperatorStateService operatorState) =>
+                {
+                    operatorState.SetMode(OperatorMode.Live);
+                    return Results.Ok(StreamDeckResponse.Ok("Mode set to Live"));
+                })
+            .WithName("StreamDeck_SetLiveMode")
+            .Produces<StreamDeckResponse>(StatusCodes.Status200OK);
+    }
+}
+
+/// <summary>
+/// Streaming status data payload.
+/// </summary>
+public sealed record StreamingStatusData(bool IsRunning, string State);
+
+/// <summary>
+/// Operator mode data payload.
+/// </summary>
+public sealed record OperatorModeData(string Mode);

--- a/src/Thiccdal.API/StreamDeck/StreamDeckResponse.cs
+++ b/src/Thiccdal.API/StreamDeck/StreamDeckResponse.cs
@@ -1,0 +1,110 @@
+namespace Thiccdal.API.StreamDeck;
+
+/// <summary>
+/// Standard response envelope for Stream Deck API endpoints.
+/// </summary>
+/// <typeparam name="T">The data payload type.</typeparam>
+public sealed record StreamDeckResponse<T>
+{
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the optional response message.
+    /// </summary>
+    public string? Message { get; init; }
+
+    /// <summary>
+    /// Gets the optional data payload.
+    /// </summary>
+    public T? Data { get; init; }
+
+    /// <summary>
+    /// Gets the optional error message when <see cref="Success"/> is false.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Creates a successful response with data.
+    /// </summary>
+    public static StreamDeckResponse<T> Ok(T data, string? message = null)
+    {
+        return new StreamDeckResponse<T>
+        {
+            Success = true,
+            Data = data,
+            Message = message
+        };
+    }
+
+    /// <summary>
+    /// Creates a successful response without data.
+    /// </summary>
+    public static StreamDeckResponse<T> Ok(string? message = null)
+    {
+        return new StreamDeckResponse<T>
+        {
+            Success = true,
+            Message = message
+        };
+    }
+
+    /// <summary>
+    /// Creates a failure response.
+    /// </summary>
+    public static StreamDeckResponse<T> Fail(string error)
+    {
+        return new StreamDeckResponse<T>
+        {
+            Success = false,
+            Error = error
+        };
+    }
+}
+
+/// <summary>
+/// Standard response envelope for Stream Deck API endpoints without data payloads.
+/// </summary>
+public sealed record StreamDeckResponse
+{
+    /// <summary>
+    /// Gets a value indicating whether the operation succeeded.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets the optional response message.
+    /// </summary>
+    public string? Message { get; init; }
+
+    /// <summary>
+    /// Gets the optional error message when <see cref="Success"/> is false.
+    /// </summary>
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Creates a successful response.
+    /// </summary>
+    public static StreamDeckResponse Ok(string? message = null)
+    {
+        return new StreamDeckResponse
+        {
+            Success = true,
+            Message = message
+        };
+    }
+
+    /// <summary>
+    /// Creates a failure response.
+    /// </summary>
+    public static StreamDeckResponse Fail(string error)
+    {
+        return new StreamDeckResponse
+        {
+            Success = false,
+            Error = error
+        };
+    }
+}

--- a/src/Thiccdal/Program.cs
+++ b/src/Thiccdal/Program.cs
@@ -1,6 +1,7 @@
 using Thiccdal;
 using Thiccdal.API.Status;
 using Thiccdal.API.Restream;
+using Thiccdal.API.StreamDeck;
 using Thiccdal.AI;
 using Thiccdal.Components;
 using Thiccdal.Data;
@@ -62,6 +63,7 @@ await app.Services.InitializeDatabase(app.Lifetime.ApplicationStopping);
 app.MapDefaultEndpoints();
 app.MapStatusEndpoints();
 app.MapRestreamEndpoints();
+app.MapStreamDeckEndpoints();
 app.MapTwitchEndpoints();
 app.MapYouTubeEndpoints();
 


### PR DESCRIPTION
## Summary

Adds a REST API optimized for Stream Deck integration at `/api/streamdeck` with 22 endpoints that accept simple GET/POST requests with minimal payloads.

## Endpoints

| Group | Endpoints |
|-------|-----------|
| **Streaming** | `GET /status`, `POST /go-live`, `POST /stop` |
| **Restream** | `GET /status`, `POST /start`, `POST /stop`, `POST /destinations/{platform}/enable\|disable\|toggle` |
| **Teleprompter** | `POST /scroll/up`, `POST /scroll/down` |
| **Overlay** | `GET /components`, `POST /{componentName}/test` |
| **Questions** | `GET /`, `POST /next`, `POST /dismiss`, `POST /clear`, `POST /autodetect/enable\|disable\|toggle` |
| **Chat** | `POST /send?message={text}` |
| **Operator** | `GET /mode`, `POST /mode/prelive`, `POST /mode/live` |

## Design Decisions

- **Empty POST bodies**: All POST endpoints accept empty request bodies for Stream Deck compatibility
- **Query parameters**: Input data uses query parameters (e.g., `?message=text`) rather than JSON bodies
- **Standardized responses**: All endpoints return `{ success, message, data, error }` envelope
- **Path-based actions**: Toggle/enable/disable actions use distinct paths rather than request bodies

## Files Changed

- `src/Thiccdal.API/StreamDeck/StreamDeckApiExtensions.cs` - All endpoint implementations
- `src/Thiccdal.API/StreamDeck/StreamDeckResponse.cs` - JSON response envelope types
- `src/Thiccdal/Program.cs` - Wires up `MapStreamDeckEndpoints()`
- `docs/help/streamdeck-api.md` - Comprehensive documentation with curl examples