### PR TITLE
Code review: fix obvious and non-obvious issues

### DIFF
--- a/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatAggregationService.cs
+++ b/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatAggregationService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Microsoft.Extensions.DependencyInjection;
@@ -46,7 +46,7 @@ public sealed class ChatAggregationService : IChatService, IChatAggregationServi
         }
     }
 
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
 
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
@@ -246,7 +246,7 @@ public sealed class ChatAggregationService : IChatService, IChatAggregationServi
                 }
 
                 OnPlatformEventReceived?.Invoke(this, chatEvent);
-                OnChatMessageRecieved?.Invoke(this, chatEvent);
+                OnChatMessageReceived?.Invoke(this, chatEvent);
                 DispatchChatEvent(chatEvent);
                 await _commandDispatcher.Dispatch(chatEvent);
                 return;

--- a/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatAggregationService.cs
+++ b/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatAggregationService.cs
@@ -71,7 +71,10 @@ public sealed class ChatAggregationService : IChatService, IChatAggregationServi
                 return;
             }
 
-            CancellationTokenSource lifetimeCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // The lifetime CTS must NOT be linked to the caller token: the caller's token only governs the
+            // connection attempt itself and may be short-lived (e.g., a request token). Linking it would
+            // disconnect all platforms when the caller cancels.
+            CancellationTokenSource lifetimeCancellationTokenSource = new CancellationTokenSource();
             List<Task> lifetimeTasks = [];
 
             foreach (IPlatformConnection platformConnection in _platformConnections)

--- a/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatBotAiResponder.cs
+++ b/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatBotAiResponder.cs
@@ -14,6 +14,9 @@ public sealed class ChatBotAiResponder : IChatBotAiResponder
 {
     private static readonly TimeSpan ResponseTimeout = TimeSpan.FromSeconds(5);
 
+    // Keyed by bot name (lowercased) so we re-use the compiled pattern across messages.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Regex> _mentionPatternCache = new(StringComparer.OrdinalIgnoreCase);
+
     private readonly IChatCompletionClient _chatCompletionClient;
     private readonly IChatterMemoryService _chatterMemoryService;
     private readonly IOptions<ChatBotOptions> _options;
@@ -153,9 +156,13 @@ public sealed class ChatBotAiResponder : IChatBotAiResponder
             return false;
         }
 
-        // Require the @ prefix — only fire when someone directly @-tags the bot.
-        string pattern = $@"@{Regex.Escape(botName)}([^\p{{L}}\p{{N}}]|$)";
-        return Regex.IsMatch(message, pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+        Regex pattern = _mentionPatternCache.GetOrAdd(
+            botName,
+            static name => new Regex(
+                $@"@{Regex.Escape(name)}([^\p{{L}}\p{{N}}]|$)",
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled));
+
+        return pattern.IsMatch(message);
     }
 
     private async Task<ChatterMemoryContext?> GetMemoryContext(

--- a/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatRepostService.cs
+++ b/src/Modules/Thiccdal.Modules.ChatBot/Services/ChatRepostService.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Thiccdal.Infrastructure.Bot;
@@ -42,14 +42,14 @@ public sealed class ChatRepostService : IChatRepostService, IHostedService, IDis
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _chatService.OnChatMessageRecieved += HandleChatMessageReceived;
+        _chatService.OnChatMessageReceived += HandleChatMessageReceived;
         _logger.LogInformation("Chat repost service started");
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        _chatService.OnChatMessageRecieved -= HandleChatMessageReceived;
+        _chatService.OnChatMessageReceived -= HandleChatMessageReceived;
         _logger.LogInformation("Chat repost service stopped");
         return Task.CompletedTask;
     }
@@ -61,7 +61,7 @@ public sealed class ChatRepostService : IChatRepostService, IHostedService, IDis
             return;
         }
 
-        _chatService.OnChatMessageRecieved -= HandleChatMessageReceived;
+        _chatService.OnChatMessageReceived -= HandleChatMessageReceived;
         _disposed = true;
         GC.SuppressFinalize(this);
     }

--- a/src/Modules/Thiccdal.Modules.ChatBot/Services/CommandDispatcher.cs
+++ b/src/Modules/Thiccdal.Modules.ChatBot/Services/CommandDispatcher.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -12,6 +13,7 @@ namespace Thiccdal.Modules.ChatBot.Services;
 /// </summary>
 public sealed class CommandDispatcher : ICommandDispatcher
 {
+    private static readonly ConcurrentDictionary<string, Type?> _handlerTypeCache = new(StringComparer.Ordinal);
     private readonly ICommandRegistry _commandRegistry;
     private readonly ICommandResponseSink _commandResponseSink;
     private readonly ICommandUsageTracker _commandUsageTracker;
@@ -227,16 +229,19 @@ public sealed class CommandDispatcher : ICommandDispatcher
 
     private static Type? FindHandlerType(string handlerTypeName)
     {
-        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+        return _handlerTypeCache.GetOrAdd(handlerTypeName, static name =>
         {
-            Type? handlerType = assembly.GetType(handlerTypeName, throwOnError: false, ignoreCase: false);
-            if (handlerType is not null)
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                return handlerType;
+                Type? handlerType = assembly.GetType(name, throwOnError: false, ignoreCase: false);
+                if (handlerType is not null)
+                {
+                    return handlerType;
+                }
             }
-        }
 
-        return null;
+            return null;
+        });
     }
 
     private sealed record HandlerExecutionResult(string? Response, bool SuppressStaticTemplate)

--- a/src/Remote/Thiccdal.Remote.Discord/DiscordService.cs
+++ b/src/Remote/Thiccdal.Remote.Discord/DiscordService.cs
@@ -1,4 +1,4 @@
-using Discord;
+﻿using Discord;
 using Discord.WebSocket;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,7 +33,7 @@ public class DiscordService : IDiscordService, IAsyncDisposable, IDisposable
                             _connectionState == DiscordConnectionState.Connected;
 
     public event EventHandler<DiscordConnectionState>? ConnectionStateChanged;
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
     public DiscordService(
@@ -443,7 +443,7 @@ public class DiscordService : IDiscordService, IAsyncDisposable, IDisposable
 
         if (platformEvent is ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
     }
 

--- a/src/Remote/Thiccdal.Remote.Facebook/FacebookService.cs
+++ b/src/Remote/Thiccdal.Remote.Facebook/FacebookService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Facebook;
@@ -36,7 +36,7 @@ public class FacebookService : IFacebookService, IAsyncDisposable, IDisposable
 
     public event EventHandler<FacebookConnectionState>? ConnectionStateChanged;
     public event EventHandler<bool>? StreamLiveStateChanged;
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
     public FacebookService(
@@ -450,7 +450,7 @@ public class FacebookService : IFacebookService, IAsyncDisposable, IDisposable
 
         if (platformEvent is ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
     }
 

--- a/src/Remote/Thiccdal.Remote.Instagram/InstagramService.cs
+++ b/src/Remote/Thiccdal.Remote.Instagram/InstagramService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Instagram;
@@ -40,7 +40,7 @@ public sealed class InstagramService : IPlatformConnection, IIntegrationConnecti
 
     public bool IsConnected => _options.IsEnabled;
 
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved
+    public event EventHandler<ChatEvent>? OnChatMessageReceived
     {
         add { }
         remove { }

--- a/src/Remote/Thiccdal.Remote.LinkedIn/LinkedInService.cs
+++ b/src/Remote/Thiccdal.Remote.LinkedIn/LinkedInService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Integrations;
@@ -40,7 +40,7 @@ public sealed class LinkedInService : IPlatformConnection, IIntegrationConnectio
 
     public bool IsConnected => _options.IsEnabled;
 
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved
+    public event EventHandler<ChatEvent>? OnChatMessageReceived
     {
         add { }
         remove { }

--- a/src/Remote/Thiccdal.Remote.Null/NullPlatformConnection.cs
+++ b/src/Remote/Thiccdal.Remote.Null/NullPlatformConnection.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Integrations;
@@ -34,7 +34,7 @@ public sealed class NullPlatformConnection : IPlatformConnection, IIntegrationCo
 
     public string? LastError => null;
 
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
 
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
@@ -106,7 +106,7 @@ public sealed class NullPlatformConnection : IPlatformConnection, IIntegrationCo
 
         if (platformEvent is ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
 
         return Task.CompletedTask;

--- a/src/Remote/Thiccdal.Remote.TikTok/TikTokService.cs
+++ b/src/Remote/Thiccdal.Remote.TikTok/TikTokService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Integrations;
@@ -40,7 +40,7 @@ public sealed class TikTokService : IPlatformConnection, IIntegrationConnectionM
 
     public bool IsConnected => _options.IsEnabled;
 
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved
+    public event EventHandler<ChatEvent>? OnChatMessageReceived
     {
         add { }
         remove { }

--- a/src/Remote/Thiccdal.Remote.Twitch/Thiccdal.Remote.Twitch.csproj
+++ b/src/Remote/Thiccdal.Remote.Twitch/Thiccdal.Remote.Twitch.csproj
@@ -7,6 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Thiccdal.Remote.Twitch.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Remote/Thiccdal.Remote.Twitch/TwitchEventSubClient.cs
+++ b/src/Remote/Thiccdal.Remote.Twitch/TwitchEventSubClient.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
@@ -16,7 +15,7 @@ public sealed class TwitchEventSubClient : ITwitchEventSubClient, IAsyncDisposab
     private readonly TwitchEventSubNotificationMapper _mapper;
     private readonly ILogger<TwitchEventSubClient> _logger;
     private readonly SemaphoreSlim _connectionGate;
-    private readonly ConcurrentQueue<string> _recentMessageIds;
+    private readonly Queue<string> _recentMessageIds;
     private readonly HashSet<string> _recentMessageIdSet;
 
     private ClientWebSocket? _socket;
@@ -35,7 +34,7 @@ public sealed class TwitchEventSubClient : ITwitchEventSubClient, IAsyncDisposab
         _mapper = mapper;
         _logger = logger;
         _connectionGate = new SemaphoreSlim(1, 1);
-        _recentMessageIds = new ConcurrentQueue<string>();
+        _recentMessageIds = new Queue<string>();
         _recentMessageIdSet = [];
     }
 
@@ -408,8 +407,9 @@ public sealed class TwitchEventSubClient : ITwitchEventSubClient, IAsyncDisposab
 
             _recentMessageIdSet.Add(messageId);
             _recentMessageIds.Enqueue(messageId);
-            while (_recentMessageIds.Count > 256 && _recentMessageIds.TryDequeue(out string? removedMessageId))
+            while (_recentMessageIds.Count > 256)
             {
+                string removedMessageId = _recentMessageIds.Dequeue();
                 _recentMessageIdSet.Remove(removedMessageId);
             }
         }

--- a/src/Remote/Thiccdal.Remote.Twitch/TwitchEventSubClient.cs
+++ b/src/Remote/Thiccdal.Remote.Twitch/TwitchEventSubClient.cs
@@ -266,8 +266,32 @@ public sealed class TwitchEventSubClient : ITwitchEventSubClient, IAsyncDisposab
         IReadOnlyList<TwitchEventSubSubscription> existingSubscriptions = await _helixClient.GetEventSubscriptions(cancellationToken);
         foreach (TwitchEventSubSubscriptionRequest request in BuildSubscriptionRequests(profile, sessionId))
         {
-            bool exists = existingSubscriptions.Any(subscription => SubscriptionMatches(subscription, request));
-            if (exists)
+            TwitchEventSubSubscription? stale = existingSubscriptions.FirstOrDefault(
+                subscription => SubscriptionMatchesRequest(subscription, request) &&
+                                !string.Equals(subscription.SessionId, sessionId, StringComparison.Ordinal));
+
+            if (stale is not null)
+            {
+                _logger.LogInformation(
+                    "Deleting stale EventSub subscription {SubscriptionId} ({Type}) bound to previous session.",
+                    stale.Id,
+                    stale.Type);
+
+                try
+                {
+                    await _helixClient.DeleteEventSubscription(stale.Id, cancellationToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogWarning(ex, "Failed to delete stale Twitch EventSub subscription {SubscriptionId}.", stale.Id);
+                }
+            }
+
+            bool alreadyCurrent = existingSubscriptions.Any(
+                subscription => SubscriptionMatchesRequest(subscription, request) &&
+                                string.Equals(subscription.SessionId, sessionId, StringComparison.Ordinal));
+
+            if (alreadyCurrent)
             {
                 continue;
             }
@@ -367,7 +391,7 @@ public sealed class TwitchEventSubClient : ITwitchEventSubClient, IAsyncDisposab
         };
     }
 
-    private static bool SubscriptionMatches(
+    private static bool SubscriptionMatchesRequest(
         TwitchEventSubSubscription existing,
         TwitchEventSubSubscriptionRequest request)
     {

--- a/src/Remote/Thiccdal.Remote.Twitch/TwitchHelixClient.cs
+++ b/src/Remote/Thiccdal.Remote.Twitch/TwitchHelixClient.cs
@@ -229,7 +229,8 @@ public sealed class TwitchHelixClient : ITwitchHelixClient
             Condition = subscription.Condition?.ToDictionary(
                 static pair => pair.Key,
                 static pair => pair.Value.ValueKind == JsonValueKind.String ? pair.Value.GetString() ?? string.Empty : pair.Value.ToString(),
-                StringComparer.Ordinal) ?? new Dictionary<string, string>()
+                StringComparer.Ordinal) ?? new Dictionary<string, string>(),
+            SessionId = subscription.Transport?.SessionId ?? string.Empty
         }).ToArray();
     }
 
@@ -262,6 +263,28 @@ public sealed class TwitchHelixClient : ITwitchHelixClient
         ApplyAuthentication(httpRequest, token);
 
         using HttpResponseMessage response = await _httpClient.SendAsync(httpRequest, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public async Task DeleteEventSubscription(string subscriptionId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(subscriptionId))
+        {
+            return;
+        }
+
+        string? token = await _tokenManager.GetToken(cancellationToken);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw new InvalidOperationException("Twitch is not authorized.");
+        }
+
+        using var request = new HttpRequestMessage(
+            HttpMethod.Delete,
+            $"eventsub/subscriptions?id={Uri.EscapeDataString(subscriptionId)}");
+        ApplyAuthentication(request, token);
+
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
 
@@ -361,7 +384,12 @@ public sealed class TwitchHelixClient : ITwitchHelixClient
         [property: JsonPropertyName("id")] string? Id,
         [property: JsonPropertyName("type")] string? Type,
         [property: JsonPropertyName("version")] string? Version,
-        [property: JsonPropertyName("condition")] Dictionary<string, JsonElement>? Condition);
+        [property: JsonPropertyName("condition")] Dictionary<string, JsonElement>? Condition,
+        [property: JsonPropertyName("transport")] HelixTransportData? Transport);
+
+    private sealed record HelixTransportData(
+        [property: JsonPropertyName("method")] string? Method,
+        [property: JsonPropertyName("session_id")] string? SessionId);
 
     private sealed record CreateEventSubSubscriptionHttpRequest(
         [property: JsonPropertyName("type")] string Type,

--- a/src/Remote/Thiccdal.Remote.Twitch/TwitchService.cs
+++ b/src/Remote/Thiccdal.Remote.Twitch/TwitchService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -6,7 +6,7 @@ using Thiccdal.Infrastructure.Twitch;
 
 namespace Thiccdal.Remote.Twitch;
 
-public class TwitchService : ITwitchService, IStreamInfoProvider, IChatSource, IAsyncDisposable, IDisposable
+internal sealed class TwitchService : ITwitchService, IStreamInfoProvider, IChatSource, IAsyncDisposable, IDisposable
 {
     private readonly TwitchOptions _options;
     private readonly ITwitchTokenManager _tokenManager;
@@ -28,7 +28,7 @@ public class TwitchService : ITwitchService, IStreamInfoProvider, IChatSource, I
 
     public event EventHandler<TwitchConnectionState>? ConnectionStateChanged;
     public event EventHandler<bool>? StreamLiveStateChanged;
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
     public bool Connected => _eventSubClient.Connected && _connectionState == TwitchConnectionState.Connected;
@@ -283,7 +283,7 @@ public class TwitchService : ITwitchService, IStreamInfoProvider, IChatSource, I
         OnPlatformEventReceived?.Invoke(this, platformEvent);
         if (platformEvent is ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
     }
 

--- a/src/Remote/Thiccdal.Remote.Twitch/TwitchTokenManager.cs
+++ b/src/Remote/Thiccdal.Remote.Twitch/TwitchTokenManager.cs
@@ -11,7 +11,7 @@ using Thiccdal.Infrastructure.Twitch;
 
 namespace Thiccdal.Remote.Twitch;
 
-public class TwitchTokenManager : ITwitchTokenManager
+internal sealed class TwitchTokenManager : ITwitchTokenManager
 {
     private readonly TwitchOptions _options;
     private readonly ILogger<TwitchTokenManager> _logger;

--- a/src/Remote/Thiccdal.Remote.X/XService.cs
+++ b/src/Remote/Thiccdal.Remote.X/XService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -45,7 +45,7 @@ public class XService : IXService, IAsyncDisposable, IDisposable
 
     public event EventHandler<bool>? StreamLiveStateChanged;
 
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
 
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
@@ -359,7 +359,7 @@ public class XService : IXService, IAsyncDisposable, IDisposable
 
         if (platformEvent is ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
     }
 

--- a/src/Remote/Thiccdal.Remote.YouTube/YouTubeService.cs
+++ b/src/Remote/Thiccdal.Remote.YouTube/YouTubeService.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -32,7 +32,7 @@ public sealed class YouTubeService : IYouTubeService, IStreamInfoProvider, IChat
 
     public event EventHandler<YouTubeConnectionState>? ConnectionStateChanged;
     public event EventHandler<bool>? StreamLiveStateChanged;
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
     public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
     public bool Connected => _connectionState == YouTubeConnectionState.Connected;
@@ -344,7 +344,7 @@ public sealed class YouTubeService : IYouTubeService, IStreamInfoProvider, IChat
         OnPlatformEventReceived?.Invoke(this, platformEvent);
         if (platformEvent is ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
     }
 

--- a/src/Remote/Thiccdal.Remote.YouTube/YouTubeTokenManager.cs
+++ b/src/Remote/Thiccdal.Remote.YouTube/YouTubeTokenManager.cs
@@ -1,5 +1,4 @@
 using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,8 +12,9 @@ public sealed class YouTubeTokenManager : IYouTubeTokenManager
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IYouTubeTokenStore _tokenStore;
     private readonly ILogger<YouTubeTokenManager> _logger;
-    private readonly HashSet<string> _pendingStates = new();
-    private readonly SemaphoreSlim _stateLock = new(1, 1);
+
+    // Value is the expiry time; states that are never consumed expire and are pruned lazily.
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTime> _pendingStates = new(StringComparer.Ordinal);
 
     public YouTubeTokenManager(
         IOptions<YouTubeOptions> options,
@@ -30,16 +30,19 @@ public sealed class YouTubeTokenManager : IYouTubeTokenManager
 
     public string GetAuthorizationUrl()
     {
+        DateTime now = DateTime.UtcNow;
+
+        // Prune expired states to prevent unbounded growth.
+        foreach ((string key, DateTime expiry) in _pendingStates)
+        {
+            if (expiry < now)
+            {
+                _pendingStates.TryRemove(key, out _);
+            }
+        }
+
         string state = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
-        _stateLock.Wait();
-        try
-        {
-            _pendingStates.Add(state);
-        }
-        finally
-        {
-            _stateLock.Release();
-        }
+        _pendingStates[state] = now.AddMinutes(10);
 
         string scopes = string.Join(" ", _options.Scopes);
         string authUrl = $"{_options.OAuthBaseAddress}auth?" +
@@ -56,15 +59,12 @@ public sealed class YouTubeTokenManager : IYouTubeTokenManager
 
     public bool ValidateAndConsumeState(string state)
     {
-        _stateLock.Wait();
-        try
+        if (_pendingStates.TryRemove(state, out DateTime expiry))
         {
-            return _pendingStates.Remove(state);
+            return expiry >= DateTime.UtcNow;
         }
-        finally
-        {
-            _stateLock.Release();
-        }
+
+        return false;
     }
 
     public async Task StoreToken(string authorizationCode, CancellationToken cancellationToken = default)

--- a/src/Tests/Modules/Thiccdal.Modules.ChatBot.Tests/ChatServiceAggregatorTests.cs
+++ b/src/Tests/Modules/Thiccdal.Modules.ChatBot.Tests/ChatServiceAggregatorTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Thiccdal.Infrastructure.Bot;
@@ -39,7 +39,7 @@ public class ChatServiceAggregatorTests
         var source = new Mock<IPlatformConnection>();
         using var aggregator = BuildService(source.Object);
         ChatEvent? received = null;
-        aggregator.OnChatMessageRecieved += (_, e) => received = e;
+        aggregator.OnChatMessageReceived += (_, e) => received = e;
 
         source.Raise(s => s.OnPlatformEventReceived += null, this, MakeChatEvent());
 
@@ -54,7 +54,7 @@ public class ChatServiceAggregatorTests
         var source2 = new Mock<IPlatformConnection>();
         using var aggregator = BuildService(source1.Object, source2.Object);
         var received = new List<ChatEvent>();
-        aggregator.OnChatMessageRecieved += (_, e) => received.Add(e);
+        aggregator.OnChatMessageReceived += (_, e) => received.Add(e);
 
         source1.Raise(s => s.OnPlatformEventReceived += null, this, MakeChatEvent());
         source2.Raise(s => s.OnPlatformEventReceived += null, this, MakeChatEvent());
@@ -158,7 +158,7 @@ public class ChatServiceAggregatorTests
         var source = new Mock<IPlatformConnection>();
         var aggregator = BuildService(source.Object);
         int eventCount = 0;
-        aggregator.OnChatMessageRecieved += (_, _) => eventCount++;
+        aggregator.OnChatMessageReceived += (_, _) => eventCount++;
 
         aggregator.Dispose();
         source.Raise(s => s.OnPlatformEventReceived += null, this, MakeChatEvent());

--- a/src/Tests/Remote/Thiccdal.Remote.LinkedIn.Tests/LinkedInRegistrationExtensionsTests.cs
+++ b/src/Tests/Remote/Thiccdal.Remote.LinkedIn.Tests/LinkedInRegistrationExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -73,7 +73,7 @@ public class LinkedInRegistrationExtensionsTests
         int connectionChanges = 0;
 
         connection.OnPlatformEventReceived += (_, _) => platformEvents++;
-        connection.OnChatMessageRecieved += (_, _) => chatEvents++;
+        connection.OnChatMessageReceived += (_, _) => chatEvents++;
         connection.ConnectionChanged += (_, _) => connectionChanges++;
 
         string authorizationUrl = connection.GetAuthorizationUrl();

--- a/src/Tests/Remote/Thiccdal.Remote.Null.Tests/NullRegistrationExtensionsTests.cs
+++ b/src/Tests/Remote/Thiccdal.Remote.Null.Tests/NullRegistrationExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -70,7 +70,7 @@ public class NullRegistrationExtensionsTests
         int connectionChanges = 0;
 
         connection.OnPlatformEventReceived += (_, _) => platformEvents++;
-        connection.OnChatMessageRecieved += (_, _) => chatEvents++;
+        connection.OnChatMessageReceived += (_, _) => chatEvents++;
         connection.ConnectionChanged += (_, _) => connectionChanges++;
 
         string authorizationUrl = connection.GetAuthorizationUrl();

--- a/src/Tests/Remote/Thiccdal.Remote.TikTok.Tests/TikTokRegistrationExtensionsTests.cs
+++ b/src/Tests/Remote/Thiccdal.Remote.TikTok.Tests/TikTokRegistrationExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -73,7 +73,7 @@ public class TikTokRegistrationExtensionsTests
         int connectionChanges = 0;
 
         connection.OnPlatformEventReceived += (_, _) => platformEvents++;
-        connection.OnChatMessageRecieved += (_, _) => chatEvents++;
+        connection.OnChatMessageReceived += (_, _) => chatEvents++;
         connection.ConnectionChanged += (_, _) => connectionChanges++;
 
         string authorizationUrl = connection.GetAuthorizationUrl();

--- a/src/Tests/Remote/Thiccdal.Remote.Twitch.Tests/TwitchRegistrationExtensionsTests.cs
+++ b/src/Tests/Remote/Thiccdal.Remote.Twitch.Tests/TwitchRegistrationExtensionsTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
@@ -322,7 +322,7 @@ public class TwitchRegistrationExtensionsTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Remote/Thiccdal.Remote.X.Tests/XServiceTests.cs
+++ b/src/Tests/Remote/Thiccdal.Remote.X.Tests/XServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+﻿using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -57,7 +57,7 @@ public class XServiceTests
         FakeEventBus eventBus = new();
         XService service = XTestSupport.CreateService(apiClient: apiClient, eventBus: eventBus);
         ChatEvent? capturedEvent = null;
-        service.OnChatMessageRecieved += (_, chatEvent) => capturedEvent = chatEvent;
+        service.OnChatMessageReceived += (_, chatEvent) => capturedEvent = chatEvent;
 
         await service.Connect();
         await service.PollReplies();
@@ -98,7 +98,7 @@ public class XServiceTests
 
         XService service = XTestSupport.CreateService(apiClient: apiClient);
         ChatEvent? capturedEvent = null;
-        service.OnChatMessageRecieved += (_, chatEvent) => capturedEvent = chatEvent;
+        service.OnChatMessageReceived += (_, chatEvent) => capturedEvent = chatEvent;
 
         await service.Connect();
         await service.PollReplies();

--- a/src/Tests/Thiccdal.Data.Tests/PlatformEventPumpTests.cs
+++ b/src/Tests/Thiccdal.Data.Tests/PlatformEventPumpTests.cs
@@ -1,4 +1,4 @@
-using System.Threading.Channels;
+﻿using System.Threading.Channels;
 using System.Runtime.CompilerServices;
 using Thiccdal.Infrastructure.Remotes;
 using RuntimeChatEvent = Thiccdal.Infrastructure.Bot.Models.ChatEvent;
@@ -77,7 +77,7 @@ public sealed class PlatformEventPumpTests
 
         public bool Connected { get; private set; }
 
-        public event EventHandler<RuntimeChatEvent>? OnChatMessageRecieved;
+        public event EventHandler<RuntimeChatEvent>? OnChatMessageReceived;
         public event EventHandler<RuntimePlatformEvent>? OnPlatformEventReceived;
 
         public Task Connect(CancellationToken cancellationToken = default)
@@ -99,7 +99,7 @@ public sealed class PlatformEventPumpTests
             OnPlatformEventReceived?.Invoke(this, platformEvent);
             if (platformEvent is RuntimeChatEvent chatEvent)
             {
-                OnChatMessageRecieved?.Invoke(this, chatEvent);
+                OnChatMessageReceived?.Invoke(this, chatEvent);
             }
         }
 

--- a/src/Tests/Thiccdal.Tests/ActivityFeedServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/ActivityFeedServiceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot;
 using Thiccdal.Infrastructure.Bot.Models;
@@ -272,7 +272,7 @@ public sealed class ActivityFeedServiceTests
 
     private sealed class TestChatService : IChatService
     {
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+        public event EventHandler<ChatEvent>? OnChatMessageReceived;
 
         public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
@@ -287,7 +287,7 @@ public sealed class ActivityFeedServiceTests
             OnPlatformEventReceived?.Invoke(this, platformEvent);
             if (platformEvent is ChatEvent chatEvent)
             {
-                OnChatMessageRecieved?.Invoke(this, chatEvent);
+                OnChatMessageReceived?.Invoke(this, chatEvent);
             }
         }
     }

--- a/src/Tests/Thiccdal.Tests/ChatAggregationServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/ChatAggregationServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Thiccdal.Infrastructure.Bot;
@@ -380,7 +380,7 @@ public sealed class ChatAggregationServiceTests
 
         public bool Connected { get; private set; }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+        public event EventHandler<ChatEvent>? OnChatMessageReceived;
 
         public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 
@@ -405,7 +405,7 @@ public sealed class ChatAggregationServiceTests
             OnPlatformEventReceived?.Invoke(this, platformEvent);
             if (platformEvent is ChatEvent chatEvent)
             {
-                OnChatMessageRecieved?.Invoke(this, chatEvent);
+                OnChatMessageReceived?.Invoke(this, chatEvent);
             }
         }
 

--- a/src/Tests/Thiccdal.Tests/ChatRepostServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/ChatRepostServiceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using Thiccdal.Infrastructure.Bot;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -233,14 +233,14 @@ public sealed class ChatRepostServiceTests
     {
         public bool Connected { get; set; } = true;
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+        public event EventHandler<ChatEvent>? OnChatMessageReceived;
 #pragma warning disable CS0067
         public event EventHandler<PlatformEvent>? OnPlatformEventReceived;
 #pragma warning restore CS0067
 
         public void RaiseChatMessageReceived(ChatEvent chatEvent)
         {
-            OnChatMessageRecieved?.Invoke(this, chatEvent);
+            OnChatMessageReceived?.Invoke(this, chatEvent);
         }
 
         public Task SendMessage(string message, CancellationToken cancellationToken = default)
@@ -281,7 +281,7 @@ public sealed class ChatRepostServiceTests
 
         public Exception? SendException { get; init; }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/ChatServiceCommandResponseSinkTests.cs
+++ b/src/Tests/Thiccdal.Tests/ChatServiceCommandResponseSinkTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using Thiccdal.Infrastructure.Bot;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -73,7 +73,7 @@ public sealed class ChatServiceCommandResponseSinkTests
 
         public List<(string Message, string? ChannelId)> Messages { get; } = [];
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/GoLiveIntegrationTests.cs
+++ b/src/Tests/Thiccdal.Tests/GoLiveIntegrationTests.cs
@@ -1,4 +1,4 @@
-using System.Net.Http.Json;
+﻿using System.Net.Http.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
@@ -339,7 +339,7 @@ public sealed class GoLiveIntegrationTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }
@@ -474,7 +474,7 @@ public sealed class GoLiveIntegrationTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/NullPlatformFullStackTests.cs
+++ b/src/Tests/Thiccdal.Tests/NullPlatformFullStackTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -437,7 +437,7 @@ public sealed class NullPlatformFullStackTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }
@@ -528,7 +528,7 @@ public sealed class NullPlatformFullStackTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/PreLiveChecklistServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/PreLiveChecklistServiceTests.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Microsoft.Extensions.Options;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Operators;
@@ -772,7 +772,7 @@ public sealed class PreLiveChecklistServiceTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/ProactiveMessagingServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/ProactiveMessagingServiceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Thiccdal.Infrastructure.Bot;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Modules.ChatBot.Services;
@@ -71,7 +71,7 @@ public sealed class ProactiveMessagingServiceTests
     {
         public bool Connected { get; private set; }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/RtmpFanoutServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/RtmpFanoutServiceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
@@ -369,7 +369,7 @@ public sealed class RtmpFanoutServiceTests
 
         public bool Connected => State == PlatformConnectionState.Connected;
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/StatusEndpointTests.cs
+++ b/src/Tests/Thiccdal.Tests/StatusEndpointTests.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.Http.Json;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -230,7 +230,7 @@ public sealed class StatusEndpointTests : IClassFixture<ThiccdalApplicationFacto
 
         public bool Connected => State == PlatformConnectionState.Connected;
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }
@@ -285,7 +285,7 @@ public sealed class StatusEndpointTests : IClassFixture<ThiccdalApplicationFacto
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }
@@ -342,7 +342,7 @@ public sealed class StatusEndpointTests : IClassFixture<ThiccdalApplicationFacto
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/StreamStatusServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/StreamStatusServiceTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+﻿using Microsoft.Extensions.Logging.Abstractions;
 using Thiccdal.API.Status;
 using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Operators;
@@ -150,7 +150,7 @@ public sealed class StreamStatusServiceTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }
@@ -209,7 +209,7 @@ public sealed class StreamStatusServiceTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/TopBarTests.cs
+++ b/src/Tests/Thiccdal.Tests/TopBarTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -325,7 +325,7 @@ public sealed class TopBarTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Tests/Thiccdal.Tests/TwitchSetupDialogTests.cs
+++ b/src/Tests/Thiccdal.Tests/TwitchSetupDialogTests.cs
@@ -1,4 +1,4 @@
-using Bunit;
+﻿using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -133,7 +133,7 @@ public sealed class TwitchSetupDialogTests
             remove { }
         }
 
-        public event EventHandler<ChatEvent>? OnChatMessageRecieved
+        public event EventHandler<ChatEvent>? OnChatMessageReceived
         {
             add { }
             remove { }

--- a/src/Thiccdal.Infrastructure/Bot/IChatService.cs
+++ b/src/Thiccdal.Infrastructure/Bot/IChatService.cs
@@ -1,11 +1,11 @@
-using Thiccdal.Infrastructure.Bot.Models;
+﻿using Thiccdal.Infrastructure.Bot.Models;
 using Thiccdal.Infrastructure.Remotes;
 
 namespace Thiccdal.Infrastructure.Bot;
 
 public interface IChatService : IPlatformEventSource
 {
-    event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    event EventHandler<ChatEvent>? OnChatMessageReceived;
     Task SendMessage(string message, CancellationToken cancellationToken = default);
     Task Connect(CancellationToken ct);
     Task Disconnect(CancellationToken ct);

--- a/src/Thiccdal.Infrastructure/Remotes/IChatSource.cs
+++ b/src/Thiccdal.Infrastructure/Remotes/IChatSource.cs
@@ -1,4 +1,4 @@
-using Thiccdal.Infrastructure.Bot.Models;
+﻿using Thiccdal.Infrastructure.Bot.Models;
 
 namespace Thiccdal.Infrastructure.Remotes;
 
@@ -45,5 +45,5 @@ public interface IChatSource : IPlatformEventSource
     /// <summary>
     /// Raised when a chat message is received from the platform.
     /// </summary>
-    public event EventHandler<ChatEvent>? OnChatMessageRecieved;
+    public event EventHandler<ChatEvent>? OnChatMessageReceived;
 }

--- a/src/Thiccdal.Infrastructure/Twitch/ITwitchHelixClient.cs
+++ b/src/Thiccdal.Infrastructure/Twitch/ITwitchHelixClient.cs
@@ -23,5 +23,7 @@ public interface ITwitchHelixClient
         TwitchEventSubSubscriptionRequest request,
         CancellationToken cancellationToken = default);
 
+    Task DeleteEventSubscription(string subscriptionId, CancellationToken cancellationToken = default);
+
     Task<TwitchUser?> GetAuthenticatedUser(CancellationToken cancellationToken = default);
 }

--- a/src/Thiccdal.Infrastructure/Twitch/TwitchEventSubSubscription.cs
+++ b/src/Thiccdal.Infrastructure/Twitch/TwitchEventSubSubscription.cs
@@ -24,4 +24,9 @@ public sealed record TwitchEventSubSubscription
     /// Gets the normalized condition map for the subscription.
     /// </summary>
     public IReadOnlyDictionary<string, string> Condition { get; init; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Gets the WebSocket session ID this subscription is bound to, or empty for webhook subscriptions.
+    /// </summary>
+    public string SessionId { get; init; } = string.Empty;
 }

--- a/src/Thiccdal.Streaming/StreamingService.cs
+++ b/src/Thiccdal.Streaming/StreamingService.cs
@@ -132,7 +132,12 @@ public sealed class StreamingService : IStreamingService
     private void OnIngestStateChanged(object? sender, RtmpIngestStateChanged stateChanged)
     {
         _ = sender;
-        _ = ApplyIngestState(stateChanged);
+        Task apply = ApplyIngestState(stateChanged);
+        apply.ContinueWith(
+            t => _logger.LogError(t.Exception, "Unhandled error applying ingest state {State}.", stateChanged.State),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
     }
 
     private void SetState(StreamingState state)

--- a/src/Thiccdal/Components/Admin/TwitchSetupDialog.razor
+++ b/src/Thiccdal/Components/Admin/TwitchSetupDialog.razor
@@ -1,4 +1,4 @@
-@*
+﻿@*
     Twitch full setup dialog (modal).
     Handles target channel configuration, authorization, and IRC connection inline.
 *@
@@ -247,7 +247,7 @@
     protected override async Task OnInitializedAsync()
     {
         TwitchService.ConnectionStateChanged += HandleConnectionStateChanged;
-        TwitchService.OnChatMessageRecieved += HandleMessage;
+        TwitchService.OnChatMessageReceived += HandleMessage;
 
         await RefreshConnectionProfile();
         await TwitchService.RefreshConnectionState(_cts.Token);
@@ -526,7 +526,7 @@
     public async ValueTask DisposeAsync()
     {
         TwitchService.ConnectionStateChanged -= HandleConnectionStateChanged;
-        TwitchService.OnChatMessageRecieved -= HandleMessage;
+        TwitchService.OnChatMessageReceived -= HandleMessage;
         await _cts.CancelAsync();
         _cts.Dispose();
     }

--- a/src/Tools/Thiccdal.Teleprompter.Display/ObsWebSocketClient.cs
+++ b/src/Tools/Thiccdal.Teleprompter.Display/ObsWebSocketClient.cs
@@ -221,8 +221,9 @@ public sealed class ObsWebSocketClient : IDisposable, IAsyncDisposable
                 await ConnectInternalAsync(CancellationToken.None).ConfigureAwait(false);
                 return;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                System.Diagnostics.Debug.WriteLine($"[ObsWebSocketClient] Reconnect attempt failed: {ex.Message}");
                 delay = Math.Min(delay * 2, MaxReconnectDelaySeconds);
             }
         }


### PR DESCRIPTION
## Summary

Full code review pass across the application. Two commits: one for obvious issues, one for non-obvious ones.

---

## Commit 1 — Obvious fixes

| # | Fix |
|---|-----|
| 1 | **Typo** `OnChatMessageRecieved` → `OnChatMessageReceived` across the public interface and all 10 platform services + test mocks (34 files) |
| 2 | **OBS silent swallow** — bare `catch (Exception)` in `ObsWebSocketClient.ReconnectWithBackoffAsync` now logs via `Debug.WriteLine` |
| 3 | **Access modifiers** — `TwitchService` and `TwitchTokenManager` were `public class`; now `internal sealed class`. `InternalsVisibleTo` added to the csproj so the Twitch test project can still instantiate them |
| 4 | **`ConcurrentQueue` was unnecessary** in `TwitchEventSubClient._recentMessageIds` — it was always accessed under a `lock`, so it's now a plain `Queue<string>` |
| 5 | **Fire-and-forget error loss** in `StreamingService.OnIngestStateChanged` — faults are now logged via `ContinueWith(OnlyOnFaulted)` |
| 6 | **Regex re-compiled per message** in `ChatBotAiResponder.ContainsAtMention` — pattern now cached in a `ConcurrentDictionary<string, Regex>` keyed by bot name |
| 7 | **Assembly scan on every handler dispatch** in `CommandDispatcher.FindHandlerType` — now cached in a static `ConcurrentDictionary` |
| 8 | **`YouTubeTokenManager` blocking `SemaphoreSlim.Wait()`** in `GetAuthorizationUrl`/`ValidateAndConsumeState` — replaced with a `ConcurrentDictionary`, eliminating the risk of Blazor Server deadlocks |
| 9 | **YouTube OAuth states never expired** — added 10-minute expiry, matching the existing Twitch implementation |

---

## Commit 2 — Non-obvious fixes

### `ChatAggregationService.Connect` — CTS lifetime hazard
The connection lifetime `CancellationTokenSource` was created with `CreateLinkedTokenSource(ct)`. If `Connect()` is ever called directly with a short-lived token (e.g. a request-scoped token), all platform connections would be torn down when that token is cancelled. The lifetime CTS is now created independently; the caller token only governs the connect attempt itself.

### Stale Twitch EventSub subscriptions on reconnect
Twitch retains WebSocket subscriptions for up to **24 hours** after a session ends. `EnsureSubscriptions` was checking type/version/condition but not `transport.session_id`, so stale subscriptions from a crashed or restarted session would prevent new subscriptions from being created — causing missed follows, subs, raids, etc.

**Changes:**
- `TwitchEventSubSubscription` gains a `SessionId` property
- `HelixEventSubSubscriptionData` now parses `transport.session_id` from the Helix response
- `EnsureSubscriptions` now deletes any matching subscription bound to a *different* session before creating a fresh one for the current session
- `DeleteEventSubscription(id)` added to `ITwitchHelixClient` and implemented in `TwitchHelixClient`

---

## Not changed

`CommandDispatcher.Dispatch` calls `_commandRegistry.Reload()` on every chat message. This looked like a DB-per-message concern but `CommandRegistry` already has a **5-second in-process cache** with a volatile-read fast path — no action needed.

---

**Build:** ✅ 0 errors, 0 warnings