### PR TITLE
Code review: fix issues in RTMP server extraction

### DIFF
--- a/src/Tests/Thiccdal.Tests/GoLiveActionServiceTests.cs
+++ b/src/Tests/Thiccdal.Tests/GoLiveActionServiceTests.cs
@@ -250,6 +250,8 @@ public sealed class GoLiveActionServiceTests
 
         public bool IsRunning { get; private set; }
 
+        public int ActiveRelayCount => 0;
+
         public Task StartFanout(CancellationToken cancellationToken = default)
         {
             _events.Add("fanout.start");

--- a/src/Thiccdal.Infrastructure/Streaming/IRtmpFanoutService.cs
+++ b/src/Thiccdal.Infrastructure/Streaming/IRtmpFanoutService.cs
@@ -11,6 +11,11 @@ public interface IRtmpFanoutService
     bool IsRunning { get; }
 
     /// <summary>
+    /// Gets the number of currently active relay sessions.
+    /// </summary>
+    int ActiveRelayCount { get; }
+
+    /// <summary>
     /// Starts RTMP fanout.
     /// </summary>
     /// <param name="cancellationToken">The cancellation token for the operation.</param>

--- a/src/Thiccdal.RtmpServer/Api/RtmpServerEndpoints.cs
+++ b/src/Thiccdal.RtmpServer/Api/RtmpServerEndpoints.cs
@@ -22,45 +22,56 @@ public static class RtmpServerEndpoints
 
     private static IResult GetStatus(
         IStreamingService streaming,
-        RtmpFanoutService fanout,
+        IRtmpFanoutService fanout,
         IDiskRecorder recorder)
     {
-        RtmpServerStatusResponse response = new RtmpServerStatusResponse(
+        return Results.Ok(BuildStatus(streaming, fanout, recorder));
+    }
+
+    private static IResult PostConfig(
+        RtmpServerConfigurationPush config,
+        IRtmpServerConfigurationHolder holder,
+        IStreamingService streaming,
+        IRtmpFanoutService fanout,
+        IDiskRecorder recorder)
+    {
+        holder.Apply(config);
+        return Results.Ok(BuildStatus(streaming, fanout, recorder));
+    }
+
+    private static async Task<IResult> PostStart(
+        IStreamingService streaming,
+        IRtmpFanoutService fanout,
+        IDiskRecorder recorder,
+        CancellationToken cancellationToken)
+    {
+        await streaming.Start(cancellationToken);
+        await fanout.StartFanout(cancellationToken);
+        return Results.Ok(BuildStatus(streaming, fanout, recorder));
+    }
+
+    private static async Task<IResult> PostStop(
+        IStreamingService streaming,
+        IRtmpFanoutService fanout,
+        IDiskRecorder recorder,
+        CancellationToken cancellationToken)
+    {
+        await fanout.StopFanout(cancellationToken);
+        await streaming.Stop(cancellationToken);
+        return Results.Ok(BuildStatus(streaming, fanout, recorder));
+    }
+
+    private static RtmpServerStatusResponse BuildStatus(
+        IStreamingService streaming,
+        IRtmpFanoutService fanout,
+        IDiskRecorder recorder)
+    {
+        return new RtmpServerStatusResponse(
             IsIngestRunning: streaming.IsRunning,
             IsFanoutRunning: fanout.IsRunning,
             IsRecording: recorder.IsRecording,
             IngestState: streaming.State.ToString(),
             ActiveRelayCount: fanout.ActiveRelayCount,
             ErrorMessage: string.Empty);
-
-        return Results.Ok(response);
-    }
-
-    private static IResult PostConfig(
-        RtmpServerConfigurationPush config,
-        IRtmpServerConfigurationHolder holder)
-    {
-        holder.Apply(config);
-        return Results.Ok();
-    }
-
-    private static async Task<IResult> PostStart(
-        IStreamingService streaming,
-        IRtmpFanoutService fanout,
-        CancellationToken cancellationToken)
-    {
-        await streaming.Start(cancellationToken);
-        await fanout.StartFanout(cancellationToken);
-        return Results.Ok();
-    }
-
-    private static async Task<IResult> PostStop(
-        IStreamingService streaming,
-        IRtmpFanoutService fanout,
-        CancellationToken cancellationToken)
-    {
-        await fanout.StopFanout(cancellationToken);
-        await streaming.Stop(cancellationToken);
-        return Results.Ok();
     }
 }

--- a/src/Thiccdal.RtmpServer/Middleware/ApiKeyMiddleware.cs
+++ b/src/Thiccdal.RtmpServer/Middleware/ApiKeyMiddleware.cs
@@ -10,7 +10,7 @@ namespace Thiccdal.RtmpServer.Middleware;
 public sealed class ApiKeyMiddleware
 {
     private const string ApiKeyHeader = "X-Api-Key";
-    private static readonly string[] ExemptPaths = ["/healthz", "/hubs/events"];
+    private static readonly string[] ExemptPaths = ["/healthz"];
 
     private readonly RequestDelegate _next;
     private readonly IOptions<RtmpServerOptions> _options;

--- a/src/Thiccdal.RtmpServer/Services/RtmpEventBridgeService.cs
+++ b/src/Thiccdal.RtmpServer/Services/RtmpEventBridgeService.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Thiccdal.Infrastructure.Streaming;
 
 namespace Thiccdal.RtmpServer.Services;
@@ -10,18 +11,21 @@ public sealed class RtmpEventBridgeService : IHostedService
 {
     private readonly IStreamingService _streamingService;
     private readonly IRtmpEventPublisher _eventPublisher;
+    private readonly ILogger<RtmpEventBridgeService> _logger;
     private StreamingState _previousState = StreamingState.Idle;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RtmpEventBridgeService"/> class.
     /// </summary>
-    public RtmpEventBridgeService(IStreamingService streamingService, IRtmpEventPublisher eventPublisher)
+    public RtmpEventBridgeService(IStreamingService streamingService, IRtmpEventPublisher eventPublisher, ILogger<RtmpEventBridgeService> logger)
     {
         ArgumentNullException.ThrowIfNull(streamingService);
         ArgumentNullException.ThrowIfNull(eventPublisher);
+        ArgumentNullException.ThrowIfNull(logger);
 
         _streamingService = streamingService;
         _eventPublisher = eventPublisher;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -41,7 +45,12 @@ public sealed class RtmpEventBridgeService : IHostedService
     private void OnStateChanged(object? sender, StreamingState state)
     {
         _ = sender;
-        _ = PublishTransition(state);
+        Task publish = PublishTransition(state);
+        publish.ContinueWith(
+            t => _logger.LogError(t.Exception, "Unhandled error publishing RTMP state transition {State}.", state),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
     }
 
     private async Task PublishTransition(StreamingState state)

--- a/src/Thiccdal.Streaming/RemoteRtmpFanoutService.cs
+++ b/src/Thiccdal.Streaming/RemoteRtmpFanoutService.cs
@@ -35,6 +35,9 @@ public sealed class RemoteRtmpFanoutService : IRtmpFanoutService
     }
 
     /// <inheritdoc/>
+    public int ActiveRelayCount => 0;
+
+    /// <inheritdoc/>
     public Task StartFanout(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Thiccdal.Streaming/RtmpServerClient.cs
+++ b/src/Thiccdal.Streaming/RtmpServerClient.cs
@@ -59,6 +59,9 @@ public sealed class RtmpServerClient : IRtmpServerClient, IAsyncDisposable
     /// <inheritdoc/>
     public async Task Connect(CancellationToken cancellationToken = default)
     {
+        // Disconnect any existing hub before building a new one.
+        await Disconnect(cancellationToken);
+
         string baseUrl;
         string apiKey;
         lock (_connectionLock)


### PR DESCRIPTION
Follow-up to the RTMP server extraction feature. Fixes found during code review.

## Changes

### `RtmpServerEndpoints`: empty response bodies
`PostConfig`, `PostStart`, and `PostStop` returned `Results.Ok()` with no body. `RtmpServerClient` called `ReadFromJsonAsync` after each call, always getting `null`, and always logging "Server returned empty response" even on success. All three endpoints now return a `RtmpServerStatusResponse` via a shared `BuildStatus` helper.

### `IRtmpFanoutService`: add `ActiveRelayCount`
`GetStatus` injected the concrete `RtmpFanoutService` solely to access `ActiveRelayCount`. Moved the property to the interface. `RemoteRtmpFanoutService` returns 0 (the real count lives inside the RTMP server process). Updated the test mock in `GoLiveActionServiceTests`.

### `RtmpEventBridgeService`: log errors from fire-and-forget
`OnStateChanged` was discarding the `Task` returned by `PublishTransitionAsync` silently. Added `ILogger` and `ContinueWith(OnlyOnFaulted)` to surface SignalR publish failures.

### `RtmpServerClient.Connect`: dispose old hub on reconnect
Repeated calls to `Connect()` built a new `HubConnection` without stopping or disposing the previous one, leaking the old connection. `Connect()` now calls `Disconnect()` first.

### `ApiKeyMiddleware`: enforce API key on SignalR hub connections
`/hubs/events` was exempt from the `X-Api-Key` check, allowing unauthenticated subscriptions to streaming events. The SignalR WebSocket upgrade is a normal HTTP request that passes through the middleware pipeline, and the client already sends the key as a header. Removed the hub path from `ExemptPaths`.